### PR TITLE
Remove sleep from test

### DIFF
--- a/spec/system/happy_path_spec.rb
+++ b/spec/system/happy_path_spec.rb
@@ -16,9 +16,8 @@ RSpec.describe 'an happy path' do
     fill_in 'searchInput', with: "Jurassic"
 
     expect(page).to have_content(I18n.t('title'))
-    expect(all('mat-card').size).to eq(10)
+    expect(page).to have_selector('mat-card', count: 10)
     fill_in 'searchInput', with: "Jurassic Park III: Island Attack"
-    sleep 1
-    expect(all('mat-card').size).to eq(1)
+    expect(page).to have_selector('mat-card', count: 1)
   end
 end


### PR DESCRIPTION
I had in mind this from the learning week. This is an issue we faced/will face often with capybara and is important to understand how capybara works.
First of all, Capybara does very well in terms of "waiting". This is why we don't need to use `sleep` when testing with capybara. When we have timing issue is usually because we are not using the proper selectors from capybara. 
Some Capybara selectors, in fact, are designed to sleep automatically. `all` is one of these selectors.
When you call `all('mat-card')` the first time, there are no matches and capybara waits automatically for them to appear.
When you call it the second time, instead, the elements are already in the page and therefore it "returns" immediatly, with the count of 10.
Sleeping for a second works but is not the best solution. What works better here is to use `expect(page).to have_selector('mat-card', count: 1)`. `have_selector` also waits until it matches, and the count argument is meant for such a case.